### PR TITLE
Disable unnecessary and unfixable eslint warnings.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
   "root": true,
   "extends": [
     "@nuxtjs"
-  ]
+  ],
+  "rules": {
+    "vue/no-v-html":"off"
+  }
 }


### PR DESCRIPTION
**Description**
> Disable vue/no-v-html in eslint.

**Issue**
Closes #276 
